### PR TITLE
Sort the labels in the unified legend

### DIFF
--- a/comut/comut.py
+++ b/comut/comut.py
@@ -1720,6 +1720,8 @@ class CoMut:
 
                 handles, labels = axis.get_legend_handles_labels()
 
+                labels, handles = zip(*sorted(zip(labels, handles), key=lambda t: t[0]))
+
                 # create label-patch dict
                 handle_lookup = dict(zip(labels, handles))
 


### PR DESCRIPTION
This patch sorts the labels in a unified legend.

By default they are ordered in an arbitrary way. This can be frustrating if the labels are numbers for example, and they are unsorted, e.g. 2,1,3 (1,2,3 is much nicer).

This is a partial attempt to address: https://github.com/vanallenlab/comut/issues/6