### PR TITLE
Add waterfall function to sort genes and samples

### DIFF
--- a/comut/comut.py
+++ b/comut/comut.py
@@ -1778,6 +1778,27 @@ class CoMut:
         return leg
 
     def waterfall(self, data):
+        '''Sort genes and samples for waterfall plot.
+
+        Params:
+        -------
+        data: pandas dataframe
+            A tidy dataframe containing data. Required columns are
+            sample, category, and value. Other columns are ignored.
+
+            Example:
+            -------
+            sample   | category | value
+            ----------------------------
+            Sample_1 | TP53     | Missense
+            Sample_1 | Gender   | Male
+
+        Returns:
+        --------
+        sorder: list of samples ordered by genes.
+        gorder: list of genes in ascending order.
+
+        '''
         # Reshape data: wide format with samples as rows and genes as columns, counting occurrences
         wide_data = data.pivot_table(index='sample', columns='category', aggfunc=len, fill_value=0)
     


### PR DESCRIPTION
Hi,

I think `waterfall` function could be a usefull feature to add.

Ref:
https://bioconductor.org/packages/devel/bioc/vignettes/maftools/inst/doc/oncoplots.html

```
from comut import comut
from comut import fileparsers
import pandas as pd

data = pd.read_csv('tutorial_data/tutorial_mutation_data.tsv', sep = '\t')
toy_comut = comut.CoMut()

sample_order, gene_order = toy_comut.waterfall(data)
toy_comut.samples = sample_order
toy_comut.add_categorical_data(data, name = 'Mutation type', category_order = gene_order)

toy_comut.plot_comut(figsize = (18,7))
toy_comut.add_unified_legend()
toy_comut.figure.savefig("comut_waterfall.png")
```
![comut_waterfall](https://github.com/vanallenlab/comut/assets/9856666/43f49f03-616a-4999-92b0-dbbb3f8c2c24)
